### PR TITLE
Feature: change query parameters

### DIFF
--- a/cmd/console/find.go
+++ b/cmd/console/find.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 
 	cex "github.com/rorycl/cexfind"
+	"github.com/rorycl/cexfind/cmd"
 )
 
 // find makes cexfind.Search queries and turns the results into
@@ -31,11 +31,9 @@ import (
 // valid items returned.
 func find(query string, strict bool) (items []list.Item, itemNo int, err error) {
 
-	queries := strings.Split(query, ",")
-	for _, q := range queries {
-		if len(q) < 4 {
-			return items, 0, errors.New("queries need to be at least 4 characters in length")
-		}
+	queries, err := cmd.QueryInputChecker(query)
+	if err != nil {
+		return items, 0, err
 	}
 
 	var results []cex.Box
@@ -73,11 +71,9 @@ func find(query string, strict bool) (items []list.Item, itemNo int, err error) 
 
 // findLocal simple returns the example list in list_example.go
 func findLocal(query string, strict bool) (items []list.Item, itemNo int, err error) {
-	queries := strings.Split(query, ",")
-	for _, q := range queries {
-		if len(q) < 4 {
-			return items, 0, errors.New("queries need to be at least 4 characters in length")
-		}
+	_, err = cmd.QueryInputChecker(query)
+	if err != nil {
+		return items, 0, err
 	}
 	return theseExampleItems, 15, nil
 }

--- a/cmd/console/go.mod
+++ b/cmd/console/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/muesli/reflow v0.3.0
-	github.com/rorycl/cexfind v0.1.4
+	github.com/rorycl/cexfind v0.0.0-00010101000000-000000000000
 )
 
 require (

--- a/cmd/inputchk.go
+++ b/cmd/inputchk.go
@@ -1,0 +1,33 @@
+// cmd provides a common query input checker used by the console and web
+// commands. The checker takes the single query input string provided by
+// each commend.
+package cmd
+
+import (
+	"errors"
+	"strings"
+)
+
+var InputTooShortErr = errors.New("each query needs to be at least 3 characters in length")
+var QuerySplitChar = ";"
+
+// QueryInputChecker checks a query input from a command and splits it
+// into individual queries using QuerySplitChar, then checks the length of
+// each part.
+func QueryInputChecker(inQueries ...string) ([]string, error) {
+	if len(inQueries) < 1 {
+		return []string{}, InputTooShortErr
+	}
+	outputQueries := []string{}
+	for _, iq := range inQueries {
+		innerQueries := strings.Split(iq, QuerySplitChar)
+		for _, q := range innerQueries {
+			q = strings.TrimSpace(q)
+			if len(q) < 3 {
+				return outputQueries, InputTooShortErr
+			}
+			outputQueries = append(outputQueries, q)
+		}
+	}
+	return outputQueries, nil
+}

--- a/cmd/inputchk_test.go
+++ b/cmd/inputchk_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFindLocal(t *testing.T) {
+
+	tests := []struct {
+		input  string
+		output []string
+		err    error
+	}{
+		{
+			input:  "",
+			output: []string{},
+			err:    InputTooShortErr,
+		},
+		{
+			input:  "one",
+			output: []string{"one"},
+			err:    nil,
+		},
+		{
+			input:  "one,two",
+			output: []string{"one,two"},
+			err:    nil,
+		},
+		{
+			input:  "one;two",
+			output: []string{"one", "two"},
+			err:    nil,
+		},
+		{
+			// second input too short
+			input:  "one;tw",
+			output: []string{"one"}, // fail
+			err:    InputTooShortErr,
+		},
+		{
+			input:  `14" laptop`,
+			output: []string{`14" laptop`},
+			err:    nil,
+		},
+		{
+			input:  `   14" laptop   `,
+			output: []string{`14" laptop`},
+			err:    nil,
+		},
+		{
+			input:  `   14" laptop   ; xy z `,
+			output: []string{`14" laptop`, "xy z"},
+			err:    nil,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			queries, err := QueryInputChecker(tt.input)
+			if err != tt.err {
+				t.Fatalf("got err %v expected err %v", err, tt.err)
+			}
+			if diff := cmp.Diff(tt.output, queries); diff != "" {
+				t.Errorf("results unexpected %s", diff)
+			}
+		})
+	}
+}

--- a/cmd/web/server_test.go
+++ b/cmd/web/server_test.go
@@ -133,13 +133,25 @@ func TestResults(t *testing.T) {
 		{
 			name:       "succeed post",
 			method:     http.MethodPost,
-			input:      "queries=abc&queries=def&strict=false",
+			input:      "query=abc&query=def&strict=false",
 			statusCode: http.StatusOK,
+		},
+		{
+			name:       "fail post query too short",
+			method:     http.MethodPost,
+			input:      "query=ab&strict=false",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "fail post query too short 2",
+			method:     http.MethodPost,
+			input:      "query=abc&query=de&strict=false",
+			statusCode: http.StatusBadRequest,
 		},
 		{
 			name:       "fail get",
 			method:     http.MethodGet,
-			input:      "queries=abc&queries=def&strict=false",
+			input:      "query=abc&query=def&strict=false",
 			statusCode: http.StatusBadRequest,
 		},
 		{

--- a/cmd/web/templates/home.html
+++ b/cmd/web/templates/home.html
@@ -36,9 +36,9 @@
 <p>Search for kit available online</p>
 <form id="trip" hx-post="./results" hx-trigger="submit" hx-target="#results">
 <section>
-<input type="text" id="queries" name="queries" required minlength="4" maxlength="400" size="400" value="
+<input type="text" id="queries" name="query" required minlength="3" maxlength="400" size="400" value="
 {{- if .Search }}
-{{ range $i, $v := .Search.Queries }}{{ if gt $i  0 }}, {{ end }}{{ $v }}{{ end }}
+{{ range $i, $v := .Search.Query }}{{ if gt $i  0 }}, {{ end }}{{ $v }}{{ end }}
 {{ end -}}
 " />
 <input type="checkbox" id="strict" name="strict" {{ if .Search.Strict }}checked{{ end }} />
@@ -46,7 +46,7 @@
 <button class="submit" type="submit">Search</button>
 </section>
 </form>
-<p>Use a comma between multiple search terms<br />
+<p>Use a semicolon between multiple search terms<br />
 Select "strict" for results that narrowly match the search terms.</p>
 </div>
 <div id="results">

--- a/query.go
+++ b/query.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -59,7 +60,7 @@ func makeQueries(queries []string, strict bool) chan boxResults {
 		defer close(results)
 
 		for _, query := range queries {
-			queryBody := strings.ReplaceAll(jsonBody, "MODEL", query)
+			queryBody := strings.ReplaceAll(jsonBody, "MODEL", url.QueryEscape(query))
 			queryBytes := []byte(queryBody)
 			response, err := postQuery(queryBytes)
 			if err != nil {

--- a/query.go
+++ b/query.go
@@ -116,6 +116,13 @@ func postQuery(queryBytes []byte) (jsonResults, error) {
 
 	err = json.Unmarshal(responseBytes, &r)
 	if err != nil {
+		var ju *json.UnmarshalTypeError
+		if errors.As(err, &ju) {
+			// no results tend to provide data that cannot be parsed,
+			// used for a general "home" type page
+			return r, errors.New("no results found")
+		}
+		// assume html page; try and extract heading
 		reason := headingExtract(responseBytes)
 		if reason == "" {
 			reason = "unknown or unmarshalling error"


### PR DESCRIPTION
Change the query parameters to:

* change the query delimiter character from "," to ";" -- closes #4 
* allow 3 character search queries -- closes #2 

This also fixes a bug where query parameters, such as the " character were not urlescaped -- closed #3 